### PR TITLE
FIX: Check if clipboardManager or listener is null

### DIFF
--- a/android/src/plugin/pasteboard/ClipboardListener.java
+++ b/android/src/plugin/pasteboard/ClipboardListener.java
@@ -74,6 +74,7 @@ public class ClipboardListener
 		// Function to remove the clipChanged listener
 		public static boolean removeClipChangedListener()
 		{
+			if ( clipboardManager == null || primaryClipChangedListener == null) { return false; }
 			// Remove the clip listener
 			clipboardManager.removePrimaryClipChangedListener( primaryClipChangedListener );
 			return true;


### PR DESCRIPTION
This is an attempt to fix issue #1 
NOTE: I have not tested this since I don't have the environment set up.